### PR TITLE
Slight refactor to use zookeeper ~> 8.0

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -26,6 +26,9 @@ platforms:
   - name: ubuntu-14.04
     driver:
       Name: exhibitor-ubuntu-1404
+  - name: ubuntu-16.04
+    driver:
+      Name: exhibitor-ubuntu-1604
   - name: centos-6
     driver:
       Name: exhibitor-centos-6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,7 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: centos-6.8
 
 suites:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default['exhibitor']['service_actions'] = [:enable, :start]
 # Gradle specifics for installation
 default['et_gradle']['version'] = '2.4'
 
+default['exhibitor']['zookeeper_version'] = '3.4.9'
 default['exhibitor']['version']        = '1.5.5'
 default['exhibitor']['user']           = 'zookeeper'
 default['exhibitor']['install_method'] = 'gradle' # maven or gradle

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,8 +10,8 @@ source_url 'https://github.com/evertrue/exhibitor-cookbook/' if respond_to?(:sou
 
 depends          'build-essential'
 depends          'java', '~> 1.35'
-depends          'runit', '~> 1.7'
-depends          'zookeeper', '~> 6.0'
+depends          'runit', '~> 3.0'
+depends          'zookeeper', '~> 8.0'
 depends          'magic', '~> 1.5'
 depends          'et_gradle', '~> 2.0'
-depends          'maven', '~> 2.2'
+depends          'maven', '~> 4.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,9 +18,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+allocated_memory = "#{(node['memory']['total'].to_i * 0.8).floor / 1024}m"
+
+node.default['zookeeper']['config_dir']  = '/opt/zookeeper/conf'
+node.default['zookeeper']['conf_file']   = 'zoo.cfg'
+node.default['zookeeper']['java_opts']   = "-Xmx#{allocated_memory}"
+
 package node['exhibitor']['patch_package']
 
-include_recipe 'zookeeper::install'
+zookeeper '3.4.9' do
+  username  node['exhibitor']['user']
+  user_home "/home/#{node['exhibitor']['user']}"
+end
 
 [
   node['exhibitor']['install_dir'],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,7 @@ node.default['zookeeper']['java_opts']   = "-Xmx#{allocated_memory}"
 
 package node['exhibitor']['patch_package']
 
-zookeeper '3.4.9' do
+zookeeper node['exhibitor']['zookeeper_version'] do
   username  node['exhibitor']['user']
   user_home "/home/#{node['exhibitor']['user']}"
 end

--- a/recipes/maven.rb
+++ b/recipes/maven.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# Maven 3 requires Java 8
+node.default['java']['jdk_version'] = '8'
+
 include_recipe 'maven'
 
 jar_path = "#{node['exhibitor']['install_dir']}/#{node['exhibitor']['version']}.jar"

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -25,6 +25,8 @@ service_conf = {
   java_home: node['java']['java_home'],
 }
 
+service_conf[:java_home] = '/usr' if service_conf[:java_home].nil?
+
 case node['exhibitor']['service_style']
 when 'upstart'
   template '/etc/init/exhibitor.conf' do


### PR DESCRIPTION
Closes #36

Doesn’t change anything else about this cookbook, but should get things updated enough to work with `zookeeper` cookbook 8.x.